### PR TITLE
feat: add readonly forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
+- [Readonly forms](#readonly-forms)
 - [Updating from props](#updating-from-props)
 - [ES6 classes](#es6-classes)
 - [ES6 maps](#es6-maps)
@@ -577,6 +578,23 @@ form.set(draft => draft + 1);
 form.set(draft => draft + 1);
 form.done();
 // form.value will update to become 3
+```
+
+### Readonly forms
+
+You may want to allow subscribers to a form, while also preventing them from making any changes. For this use case, the `readonly()` method returns a version of the form that cannot be set and cannot navigate history. Any forms branched off a readonly form will also be unable to set or navigate history.
+
+```js
+const form = new Dendriform(0);
+const readonlyForm = form.readonly();
+
+// readonlyForm can have its .value and .useValue read
+// can subscribe to changes with .onChange() etc. and can render,
+// but calling .set(), .go() or any derivatives
+// will cause an error to be thrown
+
+readonlyForm.set(1); // throws error
+
 ```
 
 ### Updating from props

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -9,7 +9,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "9.0 KB",
+        limit: "9.1 KB",
         ignore: ['react', 'react-dom']
     }
 ];

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -141,6 +141,7 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
+- [Readonly forms](#readonly-forms)
 - [Updating from props](#updating-from-props)
 - [ES6 classes](#es6-classes)
 - [ES6 maps](#es6-maps)
@@ -577,6 +578,23 @@ form.set(draft => draft + 1);
 form.set(draft => draft + 1);
 form.done();
 // form.value will update to become 3
+```
+
+### Readonly forms
+
+You may want to allow subscribers to a form, while also preventing them from making any changes. For this use case, the `readonly()` method returns a version of the form that cannot be set and cannot navigate history. Any forms branched off a readonly form will also be unable to set or navigate history.
+
+```js
+const form = new Dendriform(0);
+const readonlyForm = form.readonly();
+
+// readonlyForm can have its .value and .useValue read
+// can subscribe to changes with .onChange() etc. and can render,
+// but calling .set(), .go() or any derivatives
+// will cause an error to be thrown
+
+readonlyForm.set(1); // throws error
+
 ```
 
 ### Updating from props

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -9,7 +9,8 @@ const errors = {
     5: `sync() forms must have the same maximum number of history items configured`,
     6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`,
     7: `Cannot call .set() on an element of an es6 Set`,
-    8: `Plugin must be passed into a Dendriform instance before this operation can be called`
+    8: `Plugin must be passed into a Dendriform instance before this operation can be called`,
+    9: `Cannot call .set() or .go() on a readonly form`
 } as const;
 
 export type ErrorKey = keyof typeof errors;

--- a/packages/dendriform/src/plugins/PluginSubmit.ts
+++ b/packages/dendriform/src/plugins/PluginSubmit.ts
@@ -101,12 +101,12 @@ export class PluginSubmit<V,E=undefined> extends Plugin {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private getForm(): Dendriform<any> {
-        return this.getState().form.core.getFormAt(this.path);
+        return this.getState().form.core.getFormAt(this.path, true);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     get previous(): Dendriform<any> {
-        return this.getState().previous.core.getFormAt(this.path);
+        return this.getState().previous.core.getFormAt(this.path, true);
     }
 
     get submitting(): Dendriform<boolean> {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -3254,4 +3254,24 @@ describe(`Dendriform`, () => {
             });
         });
     });
+
+    describe(`readonly`, () => {
+
+        test(`should create readonly form`, () => {
+            const form = new Dendriform(123);
+
+            expect(() => form.readonly().set(456)).toThrow(`[Dendriform] Cannot call .set() or .go() on a readonly form`);
+            expect(() => form.readonly().undo()).toThrow(`[Dendriform] Cannot call .set() or .go() on a readonly form`);
+        });
+
+        test(`should create readonly forms branched from a readonly form`, () => {
+            const form = new Dendriform({foo: 123});
+
+            expect(() => form.readonly().branch('foo').set(456)).toThrow(`[Dendriform] Cannot call .set() or .go() on a readonly form`);
+            expect(() => form.branch('foo').set(456)).not.toThrow();
+            expect(() => form.readonly().branch('foo').set(456)).toThrow(`[Dendriform] Cannot call .set() or .go() on a readonly form`);
+            // @ts-ignore
+            expect(() => form.readonly().branch('foo').setParent({foo: 456})).toThrow(`[Dendriform] Cannot call .set() or .go() on a readonly form`);
+        });
+    });
 });


### PR DESCRIPTION
- Add readonly forms with `form.readonly()`, addresses #67 
- No breaking changes