### PR TITLE
historySync()

### DIFF
--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useState, useRef, memo} from 'react';
-import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable, cancel, diff, PluginSubmit} from 'dendriform';
+import {Dendriform, useDendriform, useInput, useCheckbox, useHistorySync, array, immerable, cancel, diff, PluginSubmit} from 'dendriform';
 import {Box, Flex} from '../components/Layout';
 import {H2, Link, Text} from '../components/Text';
 import styled from 'styled-components';
@@ -1334,7 +1334,7 @@ function Sync(): React.ReactElement {
     const nameForm = useDendriform(() => ({name: 'Bill'}), {history: 100});
     const addressForm = useDendriform(() => ({street: 'Cool St'}), {history: 100});
 
-    useSync(nameForm, addressForm);
+    useHistorySync(nameForm, addressForm);
 
     return <Region>
         {nameForm.render('name', nameForm => (
@@ -1360,7 +1360,7 @@ function MyComponent(props) {
     const nameForm = useDendriform(() => ({name: 'Bill'}), {history: 100});
     const addressForm = useDendriform(() => ({street: 'Cool St'}), {history: 100});
 
-    useSync(nameForm, addressForm);
+    useHistorySync(nameForm, addressForm);
 
     return <div>
         {nameForm.render('name', nameForm => (
@@ -1377,110 +1377,6 @@ function MyComponent(props) {
                 <button type="button" onClick={form.undo} disabled={!canUndo}>Undo</button>
                 <button type="button" onClick={form.redo} disabled={!canRedo}>Redo</button>
             </div>;
-        })}
-    </div>;
-}
-`;
-
-//
-// sync derive
-//
-
-function SyncDerive(): React.ReactElement {
-
-    const namesForm = useDendriform(() => ['Bill', 'Ben', 'Bob'], {history: 100});
-
-    const addressForm = useDendriform(() => ({
-        street: 'Cool St',
-        occupants: 0
-    }), {history: 100});
-
-    useSync(namesForm, addressForm, names => {
-        // eslint-disable-next-line no-console
-        console.log(`Deriving occupants for ${JSON.stringify(names)}`);
-        addressForm.branch('occupants').set(names.length);
-    });
-
-    const addName = useCallback(() => {
-        namesForm.set(draft => {
-            draft.push('Name ' + draft.length);
-        });
-    }, []);
-
-    return <Region>
-        <fieldset>
-            <legend>names</legend>
-            <ul>
-                {namesForm.renderAll(nameForm => <Region of="li">
-                    <label><input {...useInput(nameForm, 150)} /></label>
-                </Region>)}
-            </ul>
-            <button type="button" onClick={addName}>Add name</button>
-        </fieldset>
-
-        {addressForm.render('street', streetForm => (
-            <Region of="label">street: <input {...useInput(streetForm, 150)} /></Region>
-        ))}
-
-        {addressForm.render('occupants', occupantsForm => (
-            <Region of="code">occupants: {occupantsForm.useValue()}</Region>
-        ))}
-
-        {namesForm.render(namesForm => {
-            const {canUndo, canRedo} = namesForm.useHistory();
-            return <Region>
-                <button type="button" onClick={namesForm.undo} disabled={!canUndo}>Undo</button>
-                <button type="button" onClick={namesForm.redo} disabled={!canRedo}>Redo</button>
-            </Region>;
-        })}
-    </Region>;
-}
-
-const SyncDeriveCode = `
-function MyComponent(props) {
-
-    const namesForm = useDendriform(() => ['Bill', 'Ben', 'Bob'], {history: 100});
-
-    const addressForm = useDendriform(() => ({
-        street: 'Cool St',
-        occupants: 0
-    }), {history: 100});
-
-    useSync(namesForm, addressForm, names => {
-        addressForm.branch('occupants').set(names.length);
-    });
-
-    const addName = useCallback(() => {
-        namesForm.set(draft => {
-            draft.push('Name ' + draft.length);
-        });
-    }, []);
-
-    return <div>
-        <fieldset>
-            <legend>names</legend>
-            <ul>
-                {namesForm.renderAll(nameForm => <Region of="li">
-                    <label><input {...useInput(nameForm, 150)} /></label>
-                </Region>)}
-            </ul>
-            <button type="button" onClick={addName}>Add name</button>
-        </fieldset>
-
-        {addressForm.render('street', streetForm => (
-            <label>street: <input {...useInput(streetForm, 150)} /></label>
-        ))}
-
-        {addressForm.render('occupants', occupantsForm => (
-            <code>occupants: {occupantsForm.useValue()}</code>
-        ))}
-
-        {namesForm.render(namesForm => {
-            const {canUndo, canRedo} = namesForm.useHistory();
-            return <>
-                <button type="button" onClick={namesForm.undo} disabled={!canUndo}>Undo</button>
-                <button type="button" onClick={namesForm.redo} disabled={!canRedo}>Redo</button>
-            </>;
         })}
     </div>;
 }
@@ -2830,14 +2726,6 @@ const ADVANCED_DEMOS: DemoObject[] = [
         code: SyncCode,
         description: 'When forms are synchronised with each other, their changes throughout history are also synchronised. Type in either input and use undo and redo to see how the two forms are connected.',
         anchor: 'sync',
-        more: 'synchronising-forms'
-    },
-    {
-        title: 'Synchronising forms with deriving',
-        Demo: SyncDerive,
-        code: SyncDeriveCode,
-        description: `The useSync() hook can also accept a deriver to derive data in one direction.  This has the effect of caching each derived form state in history, and calling undo and redo will just restore the relevant derived data at that point in history.`,
-        anchor: 'syncderive',
         more: 'synchronising-forms'
     },
     {

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -9,7 +9,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "9.1 KB",
+        limit: "9.3 KB",
         ignore: ['react', 'react-dom']
     }
 ];

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -10,7 +10,9 @@ const errors = {
     6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`,
     7: `Cannot call .set() on an element of an es6 Set`,
     8: `Plugin must be passed into a Dendriform instance before this operation can be called`,
-    9: `Cannot call .set() or .go() on a readonly form`
+    9: `Cannot call .set() or .go() on a readonly form`,
+    10: `All syncHistory() forms must each have a matching non-zero number of history items configured, e.g. {history: 10}`,
+    11: `syncHistory() can only be applied to forms that have not had any changes made yet`
 } as const;
 
 export type ErrorKey = keyof typeof errors;

--- a/packages/dendriform/src/index.ts
+++ b/packages/dendriform/src/index.ts
@@ -7,6 +7,7 @@ export * from './useInput';
 export * from './useCheckbox';
 export * from './useProps';
 export * from './sync';
+export * from './syncHistory';
 export * from './diff';
 export * from './LazyDerive';
 export * from './Plugin';

--- a/packages/dendriform/src/sync.ts
+++ b/packages/dendriform/src/sync.ts
@@ -9,6 +9,8 @@ export const sync = <V,S,VP extends Plugins,SP extends Plugins>(
     derive?: DeriveCallback<V>
 ): (() => void) => {
 
+    console.warn('sync() is deprecated and will be removed in the next major version. Use historySync() instead.');
+
     if(masterForm.core.historyLimit !== slaveForm.core.historyLimit) {
         die(5);
     }

--- a/packages/dendriform/src/syncHistory.ts
+++ b/packages/dendriform/src/syncHistory.ts
@@ -1,0 +1,81 @@
+import {useEffect} from 'react';
+import {noChange} from './producePatches';
+import {die} from './errors';
+import {_chunkRegistry} from './Dendriform';
+import type {Dendriform, AnyCore} from './Dendriform';
+
+//
+// history sync
+//
+
+// state
+// set of forms whose history is to be grouped together
+const historySyncGroups = new Map<AnyCore,number>();
+let historySyncGroupsNextKey = 0;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const historySync = (...forms: Dendriform<any>[]): void => {
+    const cores = forms.map(form => form.core);
+
+    // validate args
+    if(cores.length === 0
+        || cores.some(core => core.historyLimit !== cores[0].historyLimit || core.historyLimit < 1)
+    ) {
+        die(10);
+    }
+
+    if(cores.some(core => core.state.historyIndex > 0)) {
+        die(11);
+    }
+
+    // create key
+    const thisKey = ++historySyncGroupsNextKey;
+
+    // find existing keys in common with new ones
+    const commonKeys = new Set<number>();
+    cores.forEach(core => {
+        const existing = historySyncGroups.get(core);
+        if(existing) {
+            commonKeys.add(existing);
+        }
+    });
+
+    // update common keys to match newest key
+    Array.from(historySyncGroups.entries()).forEach(([core, key]) => {
+        if(commonKeys.has(key)) {
+            historySyncGroups.set(core, thisKey);
+        }
+    });
+
+    // add passed in keys
+    cores.forEach(core => {
+        historySyncGroups.set(core, thisKey);
+    });
+}
+
+export const useHistorySync = (...forms: Dendriform<any>[]): void => {
+    useEffect(() => {
+        historySync(...forms);
+    }, []);
+};
+
+// look through historySyncGroups to find if any forms need blank history items added
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+_chunkRegistry.executeHistorySync = (changedFormSet: Set<AnyCore>, offset: number = 0): void => {
+
+    const changedSyncGroups = new Set<number>(
+        Array.from(changedFormSet)
+            .map(core => historySyncGroups.get(core) as number)
+            .filter(key => !!key)
+    );
+
+    historySyncGroups.forEach((key, core) => {
+        if(!changedFormSet.has(core) && changedSyncGroups.has(key)) {
+            if(offset) {
+                core.go(offset);
+            } else {
+                core.set('0', noChange, {});
+            }
+        }
+    });
+};


### PR DESCRIPTION
- Add `historySync` to supersede `sync` in a way that isn't disrupted by any added derivers #66 
- Deprecate `sync`